### PR TITLE
notes: Remove '#' symbol from the notes list

### DIFF
--- a/AstrakoBot/modules/notes.py
+++ b/AstrakoBot/modules/notes.py
@@ -332,9 +332,9 @@ def list_notes(update: Update, context: CallbackContext):
     msg = "Get note by `/notenumber` or `#notename` \n\n  *ID*    *Note* \n"
     for note_id, note in zip(range(1, notes), note_list):
         if note_id < 10:
-            note_name = f"`{note_id:2}.`  `#{(note.name.lower())}`\n"
+            note_name = f"`{note_id:2}.`  `{(note.name.lower())}`\n"
         else:
-            note_name = f"`{note_id}.`  `#{(note.name.lower())}`\n"
+            note_name = f"`{note_id}.`  `{(note.name.lower())}`\n"
         if len(msg) + len(note_name) > MAX_MESSAGE_LENGTH:
             update.effective_message.reply_text(
                 msg, parse_mode=ParseMode.MARKDOWN)


### PR DESCRIPTION
* This does help us in the conditions when we can't send messages in the chats to retrieve notes (e.g. bot downtimes, restricted chats, etc.).
* One of the options which is to search the note by its note name but due to the presence of this symbol, all we get in the search results are the occurances of the note names in the notes lists due to which we may find it difficult to retrieve less-used notes.
* Although this change may affect less in big-old groups, but with the passage of time it'll do its job. And this will help a lot in new chats for sure.

Signed-off-by: Pranaya Deomani <deomanipranaya007@gmail.com>