### PR TITLE
Fix accessing .message method from a NoneType object

### DIFF
--- a/AstrakoBot/modules/quotly.py
+++ b/AstrakoBot/modules/quotly.py
@@ -429,6 +429,8 @@ async def quotly(event):
     if event.fwd_from:
         return
     reply = await event.get_reply_message()
+    if reply is None:
+        return
     msg = reply.message
     repliedreply = await reply.get_reply_message()
     user = (


### PR DESCRIPTION
Adding the following condition terminates the method if 'reply' is None

Send /quotly without replying a message to reproduce the exception