### PR TITLE
Purge: qol enhancements

### DIFF
--- a/AstrakoBot/modules/helper_funcs/telethn/chatstatus.py
+++ b/AstrakoBot/modules/helper_funcs/telethn/chatstatus.py
@@ -107,3 +107,12 @@ async def can_delete_messages(message):
         return status
     else:
         return False
+
+async def user_can_purge(user_id: int, message):
+    status = False
+    if message.is_private:
+        return True
+
+    perms = await telethn.get_permissions(message.chat_id, user_id)
+    status = perms.delete_messages
+    return status

--- a/AstrakoBot/modules/purge.py
+++ b/AstrakoBot/modules/purge.py
@@ -2,6 +2,7 @@ from asyncio import sleep
 from AstrakoBot.modules.helper_funcs.telethn.chatstatus import (
     can_delete_messages,
     user_is_admin,
+    user_can_purge,
 )
 from AstrakoBot import telethn
 import time
@@ -26,6 +27,10 @@ async def purge_messages(event):
         user_id=event.sender_id, message=event
     ) and event.from_id not in [1087968824]:
         await event.reply("Only Admins are allowed to use this command")
+        return
+
+    if not await user_can_purge(user_id=event.sender_id, message=event):
+        await event.reply("You don't have the permission to delete messages")
         return
 
     if not await can_delete_messages(message=event):
@@ -71,6 +76,10 @@ async def delete_messages(event):
         user_id=event.sender_id, message=event
     ) and event.from_id not in [1087968824]:
         await event.reply("Only Admins are allowed to use this command")
+        return
+
+    if not await user_can_purge(user_id=event.sender_id, message=event):
+        await event.reply("You don't have the permission to delete messages")
         return
 
     if not await can_delete_messages(message=event):


### PR DESCRIPTION
check for delete_messages perm before deleting
the bot will be able to delete its own messages even if it's not admin
changed the replies if the bot isn't admin to more specific ones (I'm not an admin/I don't have rights to delete messages)

Note: strings used are placeholders and maintainers are free to change them to suit them
