### PR TITLE
muting: fixup problem while checking if user is muted

### DIFF
--- a/AstrakoBot/modules/muting.py
+++ b/AstrakoBot/modules/muting.py
@@ -121,10 +121,10 @@ def unmute(update: Update, context: CallbackContext) -> str:
 
     if member.status != "kicked" and member.status != "left":
         if (
-            member.can_send_messages
-            and member.can_send_media_messages
-            and member.can_send_other_messages
-            and member.can_add_web_page_previews
+            member.can_send_messages is not False
+            and member.can_send_media_messages is not False
+            and member.can_send_other_messages is not False
+            and member.can_add_web_page_previews is not False
         ):
             message.reply_text("This user already has the right to speak.")
         else:


### PR DESCRIPTION
Telegram returns False if user is restricted, and None if user is not restricted (maybe True in some scenarios?)

however the problem is that AstrakoBot keeps unmuting even if the user is not muted, tested this commit locally and everything works as intended.